### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Gathercontent.php
+++ b/src/Gathercontent.php
@@ -111,7 +111,7 @@ class Gathercontent extends Plugin
             ]);
 
             // Add in our Twig extensions
-            Craft::$app->view->twig->addExtension(new GathercontentTwigExtension());
+            Craft::$app->view->registerTwigExtension(new GathercontentTwigExtension());
 
             // Add in our console commands
             if (Craft::$app instanceof ConsoleApplication) {


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.