### PR TITLE
Fixing migration not processing all items bug

### DIFF
--- a/src/services/GatherContent_GatherContentService.php
+++ b/src/services/GatherContent_GatherContentService.php
@@ -850,7 +850,9 @@ class GatherContent_GatherContentService extends Component
         $this->finishedMigration = false;
         $items = $this->getTemplateItems($items);
         $result = [];
-        $items = array_reverse($items);
+        usort($items, function ($item1, $item2) {
+            return $item2['id'] <=> $item1['id'];
+        });
 
         if ($specificIdList !== null) {
             foreach ($items as $key => $item) {


### PR DESCRIPTION
Fixed bug that was causing certain migrations to be marked as complet…e before migrating all of the items.

The issue is that items do not come ordered by ID, and the last offset (i.e. last item to process before marking job as complete) would not always be the lowest id. Which meant any IDs higher than the last offset would be ignored.

I have added sort function to order these by id descending and tested locally against a couple of live projects.